### PR TITLE
Allow custom server selection and no-report mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Runs a speedtest using speed.aussiebroadband.com.au
 
 Options:
   -V, --version            output the version number
+  -l, --location [Sydney] [optional]    use specific server location
   -j, --json [optional]    return json
   -c, --csv [optional]     return csv format
   -s, --save [optional]    saves format to user\Documents\abb-speedtests

--- a/cli.js
+++ b/cli.js
@@ -12,6 +12,7 @@ program
   .version('1.2.0')
   .description('Runs a speedtest using speed.aussiebroadband.com.au')
   .option('-l, --location [Sydney] [optional]', 'use specific server location')
+  .option('-q, --quiet [optional]', 'disables result reporting to ABB')
   .option('-j, --json [optional]', 'return json')
   .option('-c, --csv [optional]', 'return csv format')
   .option('-s, --save [optional]', 'saves format to user\\Documents\\abb-speedtests')
@@ -41,6 +42,7 @@ program
 
     let option = {
       location: program.location,
+      quiet: program.quiet,
       json:program.json,
       csv:program.csv,
       save:program.save,

--- a/cli.js
+++ b/cli.js
@@ -4,13 +4,14 @@
  * Module dependencies.
  */
 var program = require('commander');
-var speedtest = require('./index').speedTest;
+var runSpeedTest = require('./index').runSpeedTest;
 const homedir = require('os').homedir();
 const fs = require('fs');
 
 program
-  .version('1.1.0')
+  .version('1.2.0')
   .description('Runs a speedtest using speed.aussiebroadband.com.au')
+  .option('-l, --location [Sydney] [optional]', 'use specific server location')
   .option('-j, --json [optional]', 'return json')
   .option('-c, --csv [optional]', 'return csv format')
   .option('-s, --save [optional]', 'saves format to user\\Documents\\abb-speedtests')
@@ -21,7 +22,7 @@ program
         dir = homedir+"\\Documents\\abb-speedtests";
         try {
           checkFolder(dir)
-          console.log('Saving result defualt directory:', dir)
+          console.log('Saving result default directory:', dir)
         } catch (err) {
           console.error(err)
         } 
@@ -38,7 +39,8 @@ program
         }
     }
 
-    let input = {
+    let option = {
+      location: program.location,
       json:program.json,
       csv:program.csv,
       save:program.save,
@@ -46,7 +48,7 @@ program
       saveDir: dir
     }
    
-    speedtest(input);
+    runSpeedTest(option);
   })  
   
 program.parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -36,6 +36,11 @@ async function getSpeed(option) {
     var frames = await page.frames()
     var speedFrame = frames.find(f =>f.url().indexOf("speedtestcustom") > 0)
 
+    if (option.quiet != undefined) {
+      console.log('Quiet mode. Result will not be reported to ABB.');
+      await page.evaluate("$.post=function(){}");
+    }
+
     if (option.location != undefined) {
       let locName = option.location.toLowerCase();
       console.log('Custom server location id:', locationIds[locName]);

--- a/index.js
+++ b/index.js
@@ -10,9 +10,17 @@ const util = require('util');
 const { PendingXHR } = require('pending-xhr-puppeteer');
 const fs = require('fs');
 
-async function getSpeed() {
+const locationIds = {
+  'melbourne': 14670,
+  'sydney': 15132,
+  'adelaide': 15135,
+  'brisbane': 15134,
+  'perth': 15136
+}
 
-    const chrome  = await launch(puppeteer);
+async function getSpeed(option) {
+
+    const chrome = await launch(puppeteer);
     const resp = await util.promisify(request)(`http://localhost:${chrome.port}/json/version`)
     const { webSocketDebuggerUrl } = JSON.parse(resp.body)
     const browser = await puppeteer.connect({
@@ -27,9 +35,18 @@ async function getSpeed() {
     await page.waitFor(5000)
     var frames = await page.frames()
     var speedFrame = frames.find(f =>f.url().indexOf("speedtestcustom") > 0)
+
+    if (option.location != undefined) {
+      let locName = option.location.toLowerCase();
+      console.log('Custom server location id:', locationIds[locName]);
+      await speedFrame.click("#main-content > .host-select > .host-list-single");
+      await speedFrame.click('.modal-gateway .host-listview__list .host-listview__list-item__button[data-id="' + locationIds[locName] + '"]');
+    }
+    
     await speedFrame.$("#main-content > div.button__wrapper > div > button")
     await speedFrame.click('#main-content > div.button__wrapper > div > button')
     await speedFrame.waitForSelector('.gauge-assembly',{visible:true,timeout:0})
+
     console.log('Running speedtest...')
     await speedFrame.waitForSelector('.results-container-stage-finished',{visible:true,timeout:0})
     console.log('Speedtest complete, parsing results...')
@@ -73,9 +90,9 @@ async function getSpeed() {
     return {result};
   }
   
-async function runSpeed(option){
+async function runSpeedTest(option){
   console.log('Booting speedtest');
-  let result = await getSpeed();
+  let result = await getSpeed(option);
   return new Promise(async (resolve, reject)  => {
       if(result){
           if(option.json === true){
@@ -205,4 +222,4 @@ async function launch (puppeteer) {
 
 
 
-  module.exports.speedTest = runSpeed;
+  module.exports.runSpeedTest = runSpeedTest;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abb-speedtest-cli",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "A cli tool for running aussie broadband speed test",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Provide the ability for the user to override which speed test server is used.
This allows to evaluate quality of ABB's interstate links and/or the quality/bandwidth of specific test servers.

Options are: Melbourne, Sydney, Adelaide, Brisbane and Perth

Usage examples: 
```
abb-speedtest --location Sydney
abb-speedtest -l brisbane
```

Also add a quiet mode option that disables reporting of results to ABB

This gives a choice on whether the result will appear on the Speed Test Results page in the ABB dashboard.

```
abb-speedtest -q
abb-speedtest --quiet
```