### PR TITLE
Timezone date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 # Chrome's sandboxing doesn't work in a Docker container - but that probably doesn't matter,
 # since the Docker container is itself a kind of sandbox.
 ENV CHROME_EXTRA_FLAG="--no-sandbox"
+ENV TZ=Australia/Sydney
 RUN apk update && \
     apk add chromium chromium-chromedriver nodejs npm curl && \
     adduser -D -u 1000 speedtest && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-ARG LOCALEZONE=Australia/Sydney
 FROM alpine:3.12
 LABEL maintainer="tjc@wintrmute.net"
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
@@ -6,15 +5,18 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 # Chrome's sandboxing doesn't work in a Docker container - but that probably doesn't matter,
 # since the Docker container is itself a kind of sandbox.
 ENV CHROME_EXTRA_FLAG="--no-sandbox"
-RUN apk --no-cache add curl
-RUN curl --silent "http://worldtimeapi.org/api/ip" --stderr - | grep -oP '(?<=timezone":").*(?=","unixtime)' && echo ${LOCALEZONE}
-ENV TZ=${LOCALEZONE}
 RUN apk update && \
     apk add chromium chromium-chromedriver nodejs npm curl && \
     adduser -D -u 1000 speedtest && \
     mkdir -p /app
 COPY . /app/
 WORKDIR /app
+RUN apk --no-cache add grep && \
+	curl --silent "http://worldtimeapi.org/api/ip" --stderr - | grep -oP '(?<=timezone":").*(?=","unixtime)' > /app/timezone
+RUN apk add tzdata && \
+	LOCALEZONE=$(cat /app/timezone) && \
+	ln -snf /usr/share/zoneinfo/$LOCALEZONE /etc/localtime && \
+	echo $LOCALEZONE > /etc/timezone
 RUN npm install --unsafe-perm -g && chown -R 1000 /app
 USER 1000
 ENTRYPOINT ["/usr/bin/abb-speedtest"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+ARG LOCALEZONE=Australia/Sydney
 FROM alpine:3.12
 LABEL maintainer="tjc@wintrmute.net"
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
@@ -5,7 +6,9 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 # Chrome's sandboxing doesn't work in a Docker container - but that probably doesn't matter,
 # since the Docker container is itself a kind of sandbox.
 ENV CHROME_EXTRA_FLAG="--no-sandbox"
-ENV TZ=Australia/Sydney
+RUN apk --no-cache add curl
+RUN curl --silent "http://worldtimeapi.org/api/ip" --stderr - | grep -oP '(?<=timezone":").*(?=","unixtime)' && echo ${LOCALEZONE}
+ENV TZ=${LOCALEZONE}
 RUN apk update && \
     apk add chromium chromium-chromedriver nodejs npm curl && \
     adduser -D -u 1000 speedtest && \

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Then to run it:
 docker run --rm abb-speedtest
 # Optionally, include parameters like this:
 docker run --rm abb-speedtest --json
+# You can also set the Docker container timezone like this:
+docker run --rm -e TZ=Australia/Sydney abb-speedtest
 ```
 
 In these cases, you do not need to install any dependencies, apart from having a working Docker system.

--- a/README.md
+++ b/README.md
@@ -74,14 +74,21 @@ Instead of installing all components directly, you can also build a Docker conta
 ```
 docker build --tag=abb-speedtest .
 ```
+Note: Australia/Sydney is defined in the Dockerfile as the default Timezone.
+
+Add the following environment variable to your run command (Replacing STATE with your location) to specify an alternate Timezone.
+
+```
+-e TZ=Australia/STATE
+```
 
 Then to run it:
 ```
 docker run --rm abb-speedtest
 # Optionally, include parameters like this:
 docker run --rm abb-speedtest --json
-# You can also set the Docker container timezone like this:
-docker run --rm -e TZ=Australia/Sydney abb-speedtest
+# You can also set the Docker container timezone manually like this:
+docker run --rm -e TZ=Australia/Perth abb-speedtest
 ```
 
 In these cases, you do not need to install any dependencies, apart from having a working Docker system.

--- a/README.md
+++ b/README.md
@@ -74,13 +74,6 @@ Instead of installing all components directly, you can also build a Docker conta
 ```
 docker build --tag=abb-speedtest .
 ```
-Note: Australia/Sydney is defined in the Dockerfile as the default Timezone.
-
-Add the following environment variable to your run command (Replacing STATE with your location) to specify an alternate Timezone.
-
-```
--e TZ=Australia/STATE
-```
 
 Then to run it:
 ```

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ async function getSpeed(option) {
       let jitter = document.querySelector('#root > div > div.test.test--finished.test--in-progress > div.container > main > div.results-container.results-container-stage-finished > div.results-latency > div.result-tile.result-tile-jitter > div.result-body > div > div > span').innerText;
       let download = document.querySelector('#root > div > div.test.test--finished.test--in-progress > div.container > main > div.results-container.results-container-stage-finished > div.results-speed > div.result-tile.result-tile-download > div.result-body > div > div > span').innerText;
       let upload = document.querySelector('#root > div > div.test.test--finished.test--in-progress > div.container > main > div.results-container.results-container-stage-finished > div.results-speed > div.result-tile.result-tile-upload > div.result-body > div > div > span').innerText;
-      let date = new Date().toLocaleString("en-AU");
+      let date = new Date().toLocaleString("en-AU", "Australia").replace(/0/, '').replace(/0/, '');
       let isodate = new Date().toISOString();
       let res = {
         location,ping,jitter,download,upload,date,isodate

--- a/index.js
+++ b/index.js
@@ -66,20 +66,6 @@ async function getSpeed(option) {
     await pendingXHR.waitForAllXhrFinished();
 
     const result = await speedFrame.evaluate(() => {
-      function timenow(){
-          var now= new Date(), 
-          ampm= 'am', 
-          h= now.getHours(), 
-          m= now.getMinutes(), 
-          s= now.getSeconds();
-          if(h>= 12){
-              if(h>12) h -= 12;
-              ampm= 'pm';
-          }
-          if(m<10) m= '0'+m;
-          if(s<10) s= '0'+s;
-          return now.toLocaleDateString()+ ' ' + h + ':' + m + ':' + s + ' ' + ampm;
-      }
       let loctemp = document.querySelector('#root > div > div.test.test--finished.test--in-progress > div.container > footer > div.host-display-transition > div > div.host-display__connection.host-display__connection--sponsor > div.host-display__connection-body > h4 > span').innerText;
       let split = loctemp.split(',')
       let location = split[0];
@@ -87,7 +73,7 @@ async function getSpeed(option) {
       let jitter = document.querySelector('#root > div > div.test.test--finished.test--in-progress > div.container > main > div.results-container.results-container-stage-finished > div.results-latency > div.result-tile.result-tile-jitter > div.result-body > div > div > span').innerText;
       let download = document.querySelector('#root > div > div.test.test--finished.test--in-progress > div.container > main > div.results-container.results-container-stage-finished > div.results-speed > div.result-tile.result-tile-download > div.result-body > div > div > span').innerText;
       let upload = document.querySelector('#root > div > div.test.test--finished.test--in-progress > div.container > main > div.results-container.results-container-stage-finished > div.results-speed > div.result-tile.result-tile-upload > div.result-body > div > div > span').innerText;
-      let date = timenow();
+      let date = new Date().toLocaleString("en-AU");
       let isodate = new Date().toISOString();
       let res = {
         location,ping,jitter,download,upload,date,isodate

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ async function getSpeed(option) {
       let jitter = document.querySelector('#root > div > div.test.test--finished.test--in-progress > div.container > main > div.results-container.results-container-stage-finished > div.results-latency > div.result-tile.result-tile-jitter > div.result-body > div > div > span').innerText;
       let download = document.querySelector('#root > div > div.test.test--finished.test--in-progress > div.container > main > div.results-container.results-container-stage-finished > div.results-speed > div.result-tile.result-tile-download > div.result-body > div > div > span').innerText;
       let upload = document.querySelector('#root > div > div.test.test--finished.test--in-progress > div.container > main > div.results-container.results-container-stage-finished > div.results-speed > div.result-tile.result-tile-upload > div.result-body > div > div > span').innerText;
-      let date = new Date().toLocaleString("en-AU", "Australia").replace(/0/, '').replace(/0/, '');
+      let date = new Date().toLocaleString("en-AU", {timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone}).replace(/0/, '').replace(/0/, '');
       let isodate = new Date().toISOString();
       let res = {
         location,ping,jitter,download,upload,date,isodate


### PR DESCRIPTION
- Fixed the speedtest result date appearing in en-US format by grabbing the environment Timezone and setting the Date to that.
- The "toLocaleDateString" was too specific and only returns the Date. "toLocaleString" returns time as well as date, then removed 2 x zeros to stick with the tidy output.
- Added the suggestion to include the Timezone in the run command of the Docker image to the readme.